### PR TITLE
abipkgdiff for kernel rpms: kernel packages need debuginfo

### DIFF
--- a/binaryaudit/abicheck.py
+++ b/binaryaudit/abicheck.py
@@ -253,6 +253,16 @@ def generate_package_json(source_dir, out_filename):
                         continue
                 rpm_dict.setdefault(source.decode('utf-8'), []).append(filename)
     for key, value in list(rpm_dict.items()):
+        if "kernel" in key:
+            kernel_has_debuginfo = False
+            for values in value:
+                if "-debuginfo-" in values:
+                    kernel_has_debuginfo = True
+                    break
+            if kernel_has_debuginfo is False:
+                util.note("Dropping files with " + key + " source name because kernel packages must be accompanied by debuginfo package")
+                drop_count += len(rpm_dict[key])
+                del rpm_dict[key]
         debug_devel_only = True
         for values in value:
             if "-debuginfo-" not in values and "-devel-" not in values:

--- a/conf/binaryaudit.conf
+++ b/conf/binaryaudit.conf
@@ -1,5 +1,5 @@
 [Mariner]
-rpms_filter_patterns=-doc-,-docs-,-tests-,kernel-
+rpms_filter_patterns=-doc-,-docs-,-tests-
 new_json_file_name=grouped_packages.json
 old_json_file_name=old_grouped_packages.json
 docker_image=mariner:abidiff


### PR DESCRIPTION
In order to run abipkgdiff with a kernel package, that package
must be accompanied by a debuginfo package.

"kernel" was removed from the list of filter words, since it was
found that abipkgdiff works fine with kernel packages, as long as
there is a corresponding debuginfo package.
abicheck.generate_package_json drops any kernel packages
that don't have a debuginfo package.

Signed-off-by: Angelina Vu <vuangelina72@gmail.com>