### PR TITLE
Cleanup: Make cleanup an optional argument

### DIFF
--- a/bin/binaryaudit
+++ b/bin/binaryaudit
@@ -186,7 +186,7 @@ elif "mariner" == args.cmd:
         args.db_config
     )
     mariner_binaryaudit.get_product_id()
-    mariner_binaryaudit.perform_binary_audit(args.buildurl, args.logurl, args.source_dir, args.output_dir, all_suppressions)
+    mariner_binaryaudit.perform_binary_audit(args.buildurl, args.logurl, args.source_dir, args.output_dir, all_suppressions, args.cleanup)
 
 else:
     # This should be caught by argparse anyway

--- a/binaryaudit/cli.py
+++ b/binaryaudit/cli.py
@@ -74,6 +74,9 @@ required_args.add_argument('-i', '--source-dir', action='store', required=True,
                            help="Path to local dir with new rpms.")
 required_args.add_argument('-o', '--output-dir', action='store', required=True,
                            help="Path to local dir with output of abipkgdiff.")
+optional_args = arg_parser_mariner.add_argument_group('optional arguments')
+optional_args.add_argument('-c', '--cleanup', action="store", default=True, required=False,
+                           help="Cleanup temporary directory and files.")
 
 # binaryaudit poky ...
 arg_parser_poky = arg_parser_subs.add_parser("poky", help="RPM tools frontend.",

--- a/binaryaudit/dnf.py
+++ b/binaryaudit/dnf.py
@@ -12,7 +12,7 @@ from binaryaudit import util
 
 
 def process_downloads(source_dir, new_json_file, old_json_file, output_dir,
-                      build_id, product_id, db_conn, remaining_files, all_suppressions, cleanup=True):
+                      build_id, product_id, db_conn, remaining_files, all_suppressions):
     ''' Finds and downloads older versions of RPMs.
 
         Parameters:
@@ -27,43 +27,33 @@ def process_downloads(source_dir, new_json_file, old_json_file, output_dir,
         Returns:
             overall_status (str): Returns "fail" if an incompatibility is found in at least 1 RPM, otherwise returns "pass"
     '''
-    try:
-        processed_files = 0
-        overall_status = "PASSED"
-        conf_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../conf")
-        # TODO: move old dir to tmpdir for mariner
-        if not os.path.exists(source_dir + "old"):
-            os.mkdir(source_dir + "old")
-        old_rpm_dict = {}
-        with open(new_json_file, "r") as file:
-            data = json.load(file)
-        for key, values in data.items():
-            processed_files += len(data[key])
-            for value in values:
-                with rpmfile.open(source_dir + value) as rpm:
-                    name = rpm.headers.get("name")
-                old_rpm_name = download(key, source_dir, name, old_rpm_dict)
-            if old_rpm_name == "":
-                util.note("Processed {} of {} files".format(processed_files, remaining_files))
-                continue
-            with open(old_json_file, "w") as outputFile:
-                json.dump(old_rpm_dict, outputFile, indent=2)
-            ret_status = generate_abidiffs(key, source_dir, new_json_file, old_json_file, output_dir,
-                                           conf_dir, build_id, product_id, db_conn, all_suppressions, cleanup)
-            util.note("Status: {}".format(ret_status))
-            if ret_status != 0:
-                overall_status = "FAILED"
+    processed_files = 0
+    overall_status = "PASSED"
+    conf_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../conf")
+    # TODO: move old dir to tmpdir for mariner
+    if not os.path.exists(source_dir + "old"):
+        os.mkdir(source_dir + "old")
+    old_rpm_dict = {}
+    with open(new_json_file, "r") as file:
+        data = json.load(file)
+    for key, values in data.items():
+        processed_files += len(data[key])
+        for value in values:
+            with rpmfile.open(source_dir + value) as rpm:
+                name = rpm.headers.get("name")
+            old_rpm_name = download(key, source_dir, name, old_rpm_dict)
+        if old_rpm_name == "":
             util.note("Processed {} of {} files".format(processed_files, remaining_files))
-    finally:
-        if cleanup is True:
-            try:
-                shutil.rmtree(source_dir + "old")
-                os.remove(new_json_file)
-                os.remove(old_json_file)
-                os.remove("output_file")
-            except OSError:
-                pass
-        return overall_status
+            continue
+        with open(old_json_file, "w") as outputFile:
+            json.dump(old_rpm_dict, outputFile, indent=2)
+        ret_status = generate_abidiffs(key, source_dir, new_json_file, old_json_file, output_dir,
+                                       conf_dir, build_id, product_id, db_conn, all_suppressions, cleanup)
+        util.note("Status: {}".format(ret_status))
+        if ret_status != 0:
+            overall_status = "FAILED"
+        util.note("Processed {} of {} files".format(processed_files, remaining_files))
+    return overall_status
 
 
 def download(key, source_dir, name, old_rpm_dict):
@@ -92,7 +82,7 @@ def download(key, source_dir, name, old_rpm_dict):
 
 
 def generate_abidiffs(key, source_dir, new_json_file, old_json_file, output_dir,
-                      conf_dir, build_id, product_id, db_conn, all_suppressions, cleanup=True):
+                      conf_dir, build_id, product_id, db_conn, all_suppressions):
     ''' Runs abipkgdiff against the grouped packages.
 
         Parameters:
@@ -106,7 +96,6 @@ def generate_abidiffs(key, source_dir, new_json_file, old_json_file, output_dir,
             product_id (str): The product id
             db_conn: The db connection
             all_suppressions (list): a list of the filepaths to suppression files used
-            cleanup (bool): An option to remove temporary files and directories after running
 
         Returns:
             abipkgdiff_exit_code (int): Returns non-zero if an incompatibility found
@@ -158,9 +147,6 @@ def generate_abidiffs(key, source_dir, new_json_file, old_json_file, output_dir,
                     out = f.read()
         status = abicheck.diff_get_bit(abipkgdiff_exit_code)
         insert_db(db_conn, build_id, product_id, name, old_VR, new_VR, exec_time, status, out)
-    if cleanup is True:
-        for value in old_data[key]:
-            os.remove(source_dir + "old/" + value)
     return abipkgdiff_exit_code
 
 

--- a/binaryaudit/dnf.py
+++ b/binaryaudit/dnf.py
@@ -28,7 +28,7 @@ def process_downloads(source_dir, new_json_file, old_json_file, output_dir,
     '''
     processed_files = 0
     overall_status = "PASSED"
-    conf_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.abspath(os.path.join("..", "conf")))
+    conf_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "conf"))
     # TODO: move old dir to tmpdir for mariner
     if not os.path.exists(os.path.join(source_dir, "old")):
         os.mkdir(os.path.join(source_dir, "old"))

--- a/binaryaudit/dnf.py
+++ b/binaryaudit/dnf.py
@@ -28,17 +28,17 @@ def process_downloads(source_dir, new_json_file, old_json_file, output_dir,
     '''
     processed_files = 0
     overall_status = "PASSED"
-    conf_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../conf")
+    conf_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.abspath(os.path.join("..", "conf")))
     # TODO: move old dir to tmpdir for mariner
-    if not os.path.exists(source_dir + "old"):
-        os.mkdir(source_dir + "old")
+    if not os.path.exists(os.path.join(source_dir, "old")):
+        os.mkdir(os.path.join(source_dir, "old"))
     old_rpm_dict = {}
     with open(new_json_file, "r") as file:
         data = json.load(file)
     for key, values in data.items():
         processed_files += len(data[key])
         for value in values:
-            with rpmfile.open(source_dir + value) as rpm:
+            with rpmfile.open(os.path.join(source_dir, value)) as rpm:
                 name = rpm.headers.get("name")
             old_rpm_name = download(key, source_dir, name, old_rpm_dict)
         if old_rpm_name == "":

--- a/binaryaudit/dnf.py
+++ b/binaryaudit/dnf.py
@@ -1,7 +1,6 @@
 import json
 import os
 import rpmfile
-import shutil
 import subprocess
 import time
 import urllib.request
@@ -48,7 +47,7 @@ def process_downloads(source_dir, new_json_file, old_json_file, output_dir,
         with open(old_json_file, "w") as outputFile:
             json.dump(old_rpm_dict, outputFile, indent=2)
         ret_status = generate_abidiffs(key, source_dir, new_json_file, old_json_file, output_dir,
-                                       conf_dir, build_id, product_id, db_conn, all_suppressions, cleanup)
+                                       conf_dir, build_id, product_id, db_conn, all_suppressions)
         util.note("Status: {}".format(ret_status))
         if ret_status != 0:
             overall_status = "FAILED"

--- a/binaryaudit/mariner.py
+++ b/binaryaudit/mariner.py
@@ -17,7 +17,7 @@ def binary_audit(source_dir, output_dir, build_id, product_id, db_conn, use_supp
         cleanup_temp(cleanup, source_dir, new_json_file, old_json_file)
     return result
 
-                        
+
 def cleanup_temp(cleanup, source_dir, new_json_file, old_json_file):
     if cleanup is True:
         try:

--- a/binaryaudit/mariner.py
+++ b/binaryaudit/mariner.py
@@ -1,12 +1,29 @@
+import os
+import shutil
+
 from binaryaudit import conf
 from binaryaudit import abicheck
 from binaryaudit import dnf
 
 
-def binary_audit(source_dir, output_dir, build_id, product_id, db_conn, use_suppressions):
+def binary_audit(source_dir, output_dir, build_id, product_id, db_conn, use_suppressions, cleanup):
     new_json_file = conf.get_config("Mariner", "new_json_file_name")
     old_json_file = conf.get_config("Mariner", "old_json_file_name")
-    remaining_files = abicheck.generate_package_json(source_dir, new_json_file)
-    result = dnf.process_downloads(source_dir, new_json_file, old_json_file, output_dir,
-                                   build_id, product_id, db_conn, remaining_files, use_suppressions)
+    try:
+        remaining_files = abicheck.generate_package_json(source_dir, new_json_file)
+        result = dnf.process_downloads(source_dir, new_json_file, old_json_file, output_dir,
+                                       build_id, product_id, db_conn, remaining_files, use_suppressions)
+    finally:
+        cleanup_temp(cleanup, source_dir, new_json_file, old_json_file)
     return result
+
+                        
+def cleanup_temp(cleanup, source_dir, new_json_file, old_json_file):
+    if cleanup is True:
+        try:
+            shutil.rmtree(source_dir + "old")
+            os.remove(new_json_file)
+            os.remove(old_json_file)
+            os.remove("output_file")
+        except OSError:
+            pass

--- a/binaryaudit/mariner.py
+++ b/binaryaudit/mariner.py
@@ -21,7 +21,7 @@ def binary_audit(source_dir, output_dir, build_id, product_id, db_conn, use_supp
 def cleanup_temp(cleanup, source_dir, new_json_file, old_json_file):
     if cleanup is True:
         try:
-            shutil.rmtree(source_dir + "old")
+            shutil.rmtree(os.path.join(source_dir, "old"))
             os.remove(new_json_file)
             os.remove(old_json_file)
             os.remove("output_file")

--- a/binaryaudit/orchestrator.py
+++ b/binaryaudit/orchestrator.py
@@ -40,7 +40,7 @@ class ba_orchestrator:
         else:
             self.logger.debug("Not connected")
 
-    def perform_binary_audit(self, buildurl, logurl, source_dir, output_dir, all_suppressions) -> None:
+    def perform_binary_audit(self, buildurl, logurl, source_dir, output_dir, all_suppressions, cleanup) -> None:
         '''
         inserts product and build id into db
         calls mariner model test and waits for test result
@@ -55,7 +55,7 @@ class ba_orchestrator:
              )
         else:
             self.logger.debug("Not connected")
-        result = mariner_binary_audit(source_dir, output_dir, self.build_id, self.product_id, self.db_conn, all_suppressions)
+        result = mariner_binary_audit(source_dir, output_dir, self.build_id, self.product_id, self.db_conn, all_suppressions, cleanup)
         if self.db_conn.is_db_connected:
             self.db_conn.update_ba_test_result(
                 self.build_id,

--- a/binaryaudit/orchestrator.py
+++ b/binaryaudit/orchestrator.py
@@ -55,7 +55,8 @@ class ba_orchestrator:
              )
         else:
             self.logger.debug("Not connected")
-        result = mariner_binary_audit(source_dir, output_dir, self.build_id, self.product_id, self.db_conn, all_suppressions, cleanup)
+        result = mariner_binary_audit(source_dir, output_dir, self.build_id, self.product_id,
+                                      self.db_conn, all_suppressions, cleanup)
         if self.db_conn.is_db_connected:
             self.db_conn.update_ba_test_result(
                 self.build_id,

--- a/tests/test_dnf.py
+++ b/tests/test_dnf.py
@@ -24,7 +24,7 @@ class dnfTestSuite(unittest.TestCase):
         suppressions = [conf_dir + "/suppressions.conf"]
         dnf.generate_abidiffs("Cython-0.29.13-6.cm1.src.rpm", data_dir + "/", new_json_file,
                               old_json_file, data_dir + "/output_abidiffs/", conf_dir, "ABCD-1234", "1", None,
-                              suppressions, False)
+                              suppressions)
         with open(os.path.join(data_dir, 'output_abidiffs/python3-Cython__0.28.5-8.cm1__0.29.13-6.cm1.abidiff')) as f:
             out = f.read()
         os.remove(os.path.join(data_dir, 'output_abidiffs/python3-Cython__0.28.5-8.cm1__0.29.13-6.cm1.abidiff'))


### PR DESCRIPTION
Move the cleanup of temporary files and directory to mariner.py.
Additionally, cleanup was made into an optional argument.

Doing so allows the user to set cleanup to False if they need to view
the temporary files for debugging or other purposes.

Signed-off-by: Angelina Vu <vuangelina72@gmail.com>