### PR TITLE
Filter: Distinguish between .so and .socket

### DIFF
--- a/binaryaudit/abicheck.py
+++ b/binaryaudit/abicheck.py
@@ -224,8 +224,9 @@ def filter_rpm(filename, filter_list, rpm, drop_count):
         has_so = False
         for member in rpm.getmembers():
             member_name = str(member)
-            if ".so" in member_name and ".socket" not in member_name:
-                has_so = True
+            member_name = member_name[12:-2]
+            has_so = util.is_dso_filename(member_name)
+            if has_so is True:
                 break
         if has_so is False:
             util.note("Dropping " + filename + " RPM because it has no shared object file")

--- a/binaryaudit/abicheck.py
+++ b/binaryaudit/abicheck.py
@@ -224,7 +224,7 @@ def filter_rpm(filename, filter_list, rpm, drop_count):
         has_so = False
         for member in rpm.getmembers():
             member_name = str(member)
-            if ".so" in member_name:
+            if ".so" in member_name and ".socket" not in member_name:
                 has_so = True
                 break
         if has_so is False:

--- a/binaryaudit/util.py
+++ b/binaryaudit/util.py
@@ -1,3 +1,4 @@
+import re
 import os
 import sys
 import logging
@@ -133,3 +134,10 @@ def build_diff_filename(name, ver_old, ver_new):
         ver_new = ver_new.replace(c, "")
     fn = "{}__{}__{}.abidiff".format(name, ver_old, ver_new)
     return fn
+
+
+def is_dso_filename(filename):
+    so_reg = re.compile(r".*\.so(\.\d+)*$")
+    if so_reg.match(filename):
+        return True
+    return False

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -45,3 +45,11 @@ class UtilTestSuite(unittest.TestCase):
         exp = "rpm-libs__na__4.14.2-13.cm1.abidiff"
         ret = util.build_diff_filename(name, ver_old, ver_new)
         assert exp == ret
+
+    def test_is_dso_filename(self):
+        fn1 = "/usr/lib/libyajl.so.2.1.0"
+        fn2 = "/usr/lib/libyajl.so"
+        fn3 = "/usr/lib/libyajl.socket"
+        self.assertTrue(util.is_dso_filename(fn1))
+        self.assertTrue(util.is_dso_filename(fn2))
+        self.assertFalse(util.is_dso_filename(fn3))


### PR DESCRIPTION
Make sure that a package with a file name containing .so is actually
a shared object file and not socket.

Current implementation of shared object filtering did not take into
account .socket files, so packages that should've been filtered out were
not.

Signed-off-by: Angelina Vu <vuangelina72@gmail.com>